### PR TITLE
fix(ci): harden issue triage API request

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -61,8 +61,10 @@ jobs:
           trap 'rm -f "$RESPONSE_FILE"' EXIT
           REQUEST_OK=false
           HTTP_STATUS=curl-error
+          FAILED_ENDPOINT=""
 
           for endpoint in "${ENDPOINTS[@]}"; do
+            FAILED_ENDPOINT="$endpoint"
             HTTP_STATUS="$(curl -sS \
               --connect-timeout 15 \
               --max-time 120 \
@@ -83,14 +85,30 @@ jobs:
           done
 
           if [[ "$REQUEST_OK" != true ]]; then
-            echo "::error::Proxy API did not return an OpenAI-compatible chat completion (HTTP ${HTTP_STATUS})."
+            echo "::error::Proxy API did not return an OpenAI-compatible chat completion from ${FAILED_ENDPOINT} (HTTP ${HTTP_STATUS})."
             head -c 1000 "$RESPONSE_FILE" || true
             exit 1
           fi
 
           CONTENT="$(jq -r '.choices[0].message.content' "$RESPONSE_FILE")"
-          SUMMARY="$(jq -r '.summary_zh // empty' <<< "$CONTENT")"
-          RAW_LABELS="$(jq -c '.labels // []' <<< "$CONTENT")"
+          PARSED_CONTENT="$(jq -cn --arg content "$CONTENT" '
+            ($content | try fromjson catch null) //
+            ($content | try (capture("(?s)```(?:json)?\\s*(?<json>\\{.*\\})\\s*```").json | fromjson) catch null)
+          ')"
+
+          if ! jq -e 'type == "object"' <<< "$PARSED_CONTENT" >/dev/null; then
+            echo "::error::Model response content is not a JSON object."
+            exit 1
+          fi
+
+          SUMMARY="$(jq -r 'if (.summary_zh | type) == "string" then .summary_zh else empty end' <<< "$PARSED_CONTENT")"
+          RAW_LABELS="$(jq -c '
+            (.labels // []) |
+            if type == "array" then map(select(type == "string"))
+            elif type == "string" then [.]
+            else []
+            end
+          ' <<< "$PARSED_CONTENT")"
           LABELS="$(jq -cn \
             --argjson labels "$RAW_LABELS" \
             --argjson allowed "$ALLOWED_LABELS_JSON" \

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -48,14 +48,53 @@ jobs:
               temperature: 0.2
             }')"
 
-          RESP="$(curl -sS "${API_BASE}/chat/completions" \
-            -H "Authorization: Bearer ${API_KEY}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD")"
+          API_ROOT="${API_BASE%/}"
+          if [[ "$API_ROOT" == */chat/completions ]]; then
+            ENDPOINTS=("$API_ROOT")
+          elif [[ "$API_ROOT" == */v1 ]]; then
+            ENDPOINTS=("${API_ROOT}/chat/completions")
+          else
+            ENDPOINTS=("${API_ROOT}/chat/completions" "${API_ROOT}/v1/chat/completions")
+          fi
 
-          CONTENT="$(echo "$RESP" | jq -r '.choices[0].message.content // empty')"
-          SUMMARY="$(echo "$CONTENT" | jq -r '.summary_zh // empty')"
-          LABELS="$(echo "$CONTENT" | jq -c '.labels // []')"
+          RESPONSE_FILE="$(mktemp)"
+          trap 'rm -f "$RESPONSE_FILE"' EXIT
+          REQUEST_OK=false
+          HTTP_STATUS=curl-error
+
+          for endpoint in "${ENDPOINTS[@]}"; do
+            HTTP_STATUS="$(curl -sS \
+              --connect-timeout 15 \
+              --max-time 120 \
+              --retry 2 \
+              --retry-all-errors \
+              -o "$RESPONSE_FILE" \
+              -w '%{http_code}' \
+              "$endpoint" \
+              -H "Authorization: Bearer ${API_KEY}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" || true)"
+
+            if [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] && \
+              jq -e '.choices[0].message.content | type == "string"' "$RESPONSE_FILE" >/dev/null 2>&1; then
+              REQUEST_OK=true
+              break
+            fi
+          done
+
+          if [[ "$REQUEST_OK" != true ]]; then
+            echo "::error::Proxy API did not return an OpenAI-compatible chat completion (HTTP ${HTTP_STATUS})."
+            head -c 1000 "$RESPONSE_FILE" || true
+            exit 1
+          fi
+
+          CONTENT="$(jq -r '.choices[0].message.content' "$RESPONSE_FILE")"
+          SUMMARY="$(jq -r '.summary_zh // empty' <<< "$CONTENT")"
+          RAW_LABELS="$(jq -c '.labels // []' <<< "$CONTENT")"
+          LABELS="$(jq -cn \
+            --argjson labels "$RAW_LABELS" \
+            --argjson allowed "$ALLOWED_LABELS_JSON" \
+            '$labels | map(select(. as $label | $allowed | index($label))) | unique | .[:3]')"
 
           [ -n "$SUMMARY" ] || exit 1
 


### PR DESCRIPTION
## Summary

- support proxy secrets configured as a full chat endpoint, a v1 base URL, or a bare API root
- validate HTTP status and OpenAI-compatible response structure before parsing
- add bounded retries and safe failure diagnostics
- filter AI labels against the repository allowlist

## Reproduction

Repository smoke test run 30669179036 reached the workflow but failed because the proxy response was not JSON at the configured chat path.

## Local verification

- YAML parser
- Bash syntax for every run block
- jq label allowlist filtering
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/piexian/newapi-app/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Summary by Sourcery

加固问题分拣工作流中的 AI 摘要请求，以适配多种代理配置，并在收到无效响应时安全失败。

增强内容：
- 规范代理 API 基础 URL，在构建聊天补全端点时同时支持完整聊天端点、v1 根路径或裸 API 根路径。
- 在解析之前验证代理响应是否成功且符合 OpenAI 兼容格式，并在失败时提供更清晰的诊断信息。
- 将 AI 生成的标签限制在允许的仓库标签列表内，并为可应用的标签数量设定上限。

CI：
- 在 GitHub Actions 任务中通过超时、重试和响应文件处理，提升摘要工作流的 API 调用健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the issue triage workflow's AI summary request to handle varied proxy configurations and fail safely on invalid responses.

Enhancements:
- Normalize proxy API base URLs to support full chat endpoints, v1 roots, or bare API roots when constructing the chat completion endpoint.
- Validate that proxy responses are successful and OpenAI-compatible before parsing, and provide clearer diagnostics on failure.
- Restrict AI-generated labels to an allowed repository label list and cap the number of applied labels.

CI:
- Improve the summary workflow's API call robustness with timeouts, retries, and response file handling in the GitHub Actions job.

</details>