### PR TITLE
fix(ci): use GitHub Models for issue triage

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -9,15 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      models: read
     if: ${{ github.repository == vars.ALLOWED_REPO }}
 
     steps:
       - name: AI classify + Chinese summary
         id: ai
         env:
-          API_BASE: ${{ secrets.PROXY_API_BASE }}
-          API_KEY:  ${{ secrets.PROXY_API_KEY }}
-          MODEL:    ${{ secrets.PROXY_MODEL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE:    ${{ github.event.issue.title }}
           BODY:     ${{ github.event.issue.body }}
         run: |
@@ -37,10 +36,9 @@ jobs:
           "Issue 正文：" "$BODY")"
 
           PAYLOAD="$(jq -n \
-            --arg model "$MODEL" \
             --arg prompt "$PROMPT" \
             '{
-              model: $model,
+              model: "openai/gpt-4o-mini",
               messages: [
                 {role:"system", content:"Return only valid JSON. No markdown."},
                 {role:"user", content:$prompt}
@@ -48,44 +46,26 @@ jobs:
               temperature: 0.2
             }')"
 
-          API_ROOT="${API_BASE%/}"
-          if [[ "$API_ROOT" == */chat/completions ]]; then
-            ENDPOINTS=("$API_ROOT")
-          elif [[ "$API_ROOT" == */v1 ]]; then
-            ENDPOINTS=("${API_ROOT}/chat/completions")
-          else
-            ENDPOINTS=("${API_ROOT}/chat/completions" "${API_ROOT}/v1/chat/completions")
-          fi
-
+          ENDPOINT="https://models.github.ai/inference/chat/completions"
           RESPONSE_FILE="$(mktemp)"
           trap 'rm -f "$RESPONSE_FILE"' EXIT
-          REQUEST_OK=false
-          HTTP_STATUS=curl-error
-          FAILED_ENDPOINT=""
+          HTTP_STATUS="$(curl -sS \
+            --connect-timeout 15 \
+            --max-time 120 \
+            --retry 2 \
+            --retry-all-errors \
+            -o "$RESPONSE_FILE" \
+            -w '%{http_code}' \
+            "$ENDPOINT" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" || true)"
 
-          for endpoint in "${ENDPOINTS[@]}"; do
-            FAILED_ENDPOINT="$endpoint"
-            HTTP_STATUS="$(curl -sS \
-              --connect-timeout 15 \
-              --max-time 120 \
-              --retry 2 \
-              --retry-all-errors \
-              -o "$RESPONSE_FILE" \
-              -w '%{http_code}' \
-              "$endpoint" \
-              -H "Authorization: Bearer ${API_KEY}" \
-              -H "Content-Type: application/json" \
-              -d "$PAYLOAD" || true)"
-
-            if [[ "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] && \
-              jq -e '.choices[0].message.content | type == "string"' "$RESPONSE_FILE" >/dev/null 2>&1; then
-              REQUEST_OK=true
-              break
-            fi
-          done
-
-          if [[ "$REQUEST_OK" != true ]]; then
-            echo "::error::Proxy API did not return an OpenAI-compatible chat completion from ${FAILED_ENDPOINT} (HTTP ${HTTP_STATUS})."
+          if [[ ! "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] || \
+            ! jq -e '.choices[0].message.content | type == "string"' "$RESPONSE_FILE" >/dev/null 2>&1; then
+            echo "::error::GitHub Models did not return a compatible chat completion (HTTP ${HTTP_STATUS})."
             head -c 1000 "$RESPONSE_FILE" || true
             exit 1
           fi

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -11,12 +11,15 @@ jobs:
       issues: write
       models: read
     if: ${{ github.repository == vars.ALLOWED_REPO }}
+    env:
+      MODELS_ENDPOINT: https://models.github.ai/inference/chat/completions
+      TRIAGE_MODEL: openai/gpt-4o-mini
 
     steps:
       - name: AI classify + Chinese summary
         id: ai
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           TITLE:    ${{ github.event.issue.title }}
           BODY:     ${{ github.event.issue.body }}
         run: |
@@ -36,9 +39,10 @@ jobs:
           "Issue 正文：" "$BODY")"
 
           PAYLOAD="$(jq -n \
+            --arg model "$TRIAGE_MODEL" \
             --arg prompt "$PROMPT" \
             '{
-              model: "openai/gpt-4o-mini",
+              model: $model,
               messages: [
                 {role:"system", content:"Return only valid JSON. No markdown."},
                 {role:"user", content:$prompt}
@@ -46,22 +50,30 @@ jobs:
               temperature: 0.2
             }')"
 
-          ENDPOINT="https://models.github.ai/inference/chat/completions"
           RESPONSE_FILE="$(mktemp)"
           trap 'rm -f "$RESPONSE_FILE"' EXIT
-          HTTP_STATUS="$(curl -sS \
-            --connect-timeout 15 \
-            --max-time 120 \
-            --retry 2 \
-            --retry-all-errors \
-            -o "$RESPONSE_FILE" \
-            -w '%{http_code}' \
-            "$ENDPOINT" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" || true)"
+          if HTTP_STATUS="$(curl -sS \
+              --connect-timeout 15 \
+              --max-time 120 \
+              --retry 2 \
+              --retry-all-errors \
+              -o "$RESPONSE_FILE" \
+              -w '%{http_code}' \
+              "$MODELS_ENDPOINT" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD")"; then
+            CURL_EXIT_CODE=0
+          else
+            CURL_EXIT_CODE=$?
+          fi
+
+          if [[ "$CURL_EXIT_CODE" -ne 0 ]]; then
+            echo "::error::GitHub Models request failed with curl exit code ${CURL_EXIT_CODE}."
+            exit 1
+          fi
 
           if [[ ! "$HTTP_STATUS" =~ ^2[0-9][0-9]$ ]] || \
             ! jq -e '.choices[0].message.content | type == "string"' "$RESPONSE_FILE" >/dev/null 2>&1; then
@@ -105,7 +117,7 @@ jobs:
 
       - name: Apply labels
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO:  ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           LABELS_JSON: ${{ steps.ai.outputs.labels }}
@@ -128,7 +140,7 @@ jobs:
 
       - name: Comment summary
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           GH_REPO:  ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           SUMMARY: ${{ steps.ai.outputs.summary }}


### PR DESCRIPTION
## Summary

- replace the Cloudflare-protected proxy with GitHub Models
- grant the workflow models: read permission and authenticate with GITHUB_TOKEN
- keep HTTP and model-response validation before applying labels or comments

## Reason

The repository smoke test reached the configured proxy but received a Cloudflare Challenge HTTP 403 from the GitHub-hosted runner. GitHub Models is directly available to Actions and avoids that external proxy failure.

## Validation

- parsed summary.yml successfully
- validated the embedded Bash script with bash -n
- verified only the workflow file is included in the commit

## Summary by Sourcery

将问题分拣（issue triage）工作流切换为直接使用 GitHub Models，而不是通过外部代理。

增强内容：
- 授予摘要工作流对 GitHub Models 的只读访问权限，并使用 `GITHUB_TOKEN` 进行身份验证。
- 简化 AI 请求逻辑，在保留 HTTP 和响应校验的前提下，使用固定的模型配置调用 GitHub Models 的聊天补全端点（chat completions endpoint）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the issue triage workflow to use GitHub Models directly instead of an external proxy.

Enhancements:
- Grant the summary workflow read access to GitHub Models and authenticate using GITHUB_TOKEN.
- Simplify the AI request logic to call the GitHub Models chat completions endpoint with fixed model configuration while retaining HTTP and response validation.

</details>